### PR TITLE
Fix package lint issues for MELPA submission

### DIFF
--- a/smali-mode.el
+++ b/smali-mode.el
@@ -14,18 +14,13 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ;;
 ;; Filename: smali-mode.el
-;; Description:
+;; Description: Smali/Baksmali mode for Emacs
 ;; Author: Tim Strazzere <strazz@gmail.com> <diff@protonmail.com>
 ;; Maintainer:
-;; Copyright (C) 2015-219, Tim Strazzere, all rights reserved.
-;; Created:
-;; Version:
-;; Last-Updated:
-;;           By:
-;;     Update #: 0
-;; URL:
+;; Copyright (C) 2015-2026, Tim Strazzere
+;; Version: 0.1.0
+;; URL: https://github.com/strazzere/Emacs-Smali
 ;; Keywords: languages smali
-;; Compatibility:
 ;;
 ;; Features that might be required by this library:
 ;;
@@ -35,7 +30,22 @@
 ;;
 ;;; Commentary:
 ;;
+;; A major mode for editing Smali files, the human-readable
+;; representation of Dalvik bytecode used by the smali/baksmali
+;; assembler/disassembler for Android.
 ;;
+;; Features:
+;; - Syntax highlighting for Dalvik opcodes, directives, access
+;;   modifiers, type descriptors, registers, and labels
+;; - Imenu support for methods, fields, and annotations
+;; - Comment syntax for `#' (standard) and `//' (non-standard)
+;;
+;; Usage:
+;; The mode activates automatically for files ending in `.smali'.
+;; To enable it manually: M-x smali-mode
+;;
+;; For the Smali language specification, see:
+;; https://source.android.com/docs/core/runtime/dalvik-bytecode
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;


### PR DESCRIPTION
Address issues flagged by `package-lint` in melpa/melpa#9875:

- Fill in `Description`, `Version`, and `URL` header fields
- Fix `Copyright` year range (was 2015-219)
- Remove empty or placeholder header fields (`Created`, `Last-Updated`, `By`, `Update #`, `Compatibility`)
- Add `Commentary` section describing the mode's features and usage