### PR TITLE
Use lexical binding

### DIFF
--- a/smali-mode.el
+++ b/smali-mode.el
@@ -1,4 +1,4 @@
-;;; smali-mode.el --- Major mode for editing Smali/Baksmali files
+;;; smali-mode.el --- Major mode for editing Smali/Baksmali files  -*- lexical-binding: t; -*-
 ;;
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Eliminating the warning when byte-compile:

> smali-mode.el:1:1: Warning: file has no ‘lexical-binding’ directive on its first line